### PR TITLE
feat: 10445 alternative to yellow highlighting of side menu and answer box

### DIFF
--- a/package/govie/settings/_colours-applied.scss
+++ b/package/govie/settings/_colours-applied.scss
@@ -48,7 +48,7 @@ $govie-secondary-text-colour: govie-colour('dark-grey') !default;
 /// @type Colour
 /// @access public
 
-$govie-focus-colour: govie-colour('yellow') !default;
+$govie-focus-colour: govie-colour('white') !default;
 
 /// Focused text colour
 ///

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ogcio/ogcio-ds",
   "description": "OGCIO-DS contains the code you need to start building a user interface for government platforms and services.",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "govie/all.js",
   "module": "govie-esm/all.mjs",
   "exports": {

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ogcio/ogcio-ds",
   "description": "OGCIO-DS contains the code you need to start building a user interface for government platforms and services.",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "main": "govie/all.js",
   "module": "govie-esm/all.mjs",
   "exports": {

--- a/src/govie/settings/_colours-applied.scss
+++ b/src/govie/settings/_colours-applied.scss
@@ -48,7 +48,7 @@ $govie-secondary-text-colour: govie-colour('dark-grey') !default;
 /// @type Colour
 /// @access public
 
-$govie-focus-colour: govie-colour('yellow') !default;
+$govie-focus-colour: govie-colour('white') !default;
 
 /// Focused text colour
 ///


### PR DESCRIPTION
Set govie-focus-colour default to "white". Different agencies override this variable in styles.