### PR TITLE
fix: distribution files path update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           mkdir -p artifact
-          zip -r artifact/ogcio-ds.zip dist/@ogcio/*
+          zip -r artifact/ogcio-ds.zip dist/*
       - uses: googleapis/release-please-action@v4
         id: release
         with:

--- a/tasks/compile-javascripts.mjs
+++ b/tasks/compile-javascripts.mjs
@@ -133,7 +133,7 @@ export function getPathByDestination(filePath) {
   let { dir, name } = parse(filePath)
 
   name = isDist
-    ? `${name.replace(/^all/, pkg.name)}-${pkg.version}`
+    ? `${name.replace(/^all/, 'ogcio-ds')}-${pkg.version}`
     : isStorybook
     ? `${name.replace(/^all/, pkg.name)}`
     : name

--- a/tasks/compile-stylesheets.mjs
+++ b/tasks/compile-stylesheets.mjs
@@ -130,7 +130,7 @@ export function getPathByDestination(filePath) {
 
   // Adjust file path by destination
   name = isDist
-    ? `${name.replace(/^all/, pkg.name)}-${pkg.version}`
+    ? `${name.replace(/^all/, 'ogcio-ds')}-${pkg.version}`
     : isStorybook
     ? `${name.replace(/^all-storybook/, pkg.name)}`
     : name

--- a/tasks/gulp/copy-to-destination.mjs
+++ b/tasks/gulp/copy-to-destination.mjs
@@ -16,7 +16,7 @@ import { destination } from '../task-arguments.mjs'
 export function copyAssets() {
   return gulp
     .src(`${slash(configPaths.assets)}/**/*`)
-    .pipe(gulp.dest(slash(join(destination, '@ogcio/assets'))))
+    .pipe(gulp.dest(slash(join(destination, '/assets'))))
 }
 
 copyAssets.displayName = 'copy:assets'


### PR DESCRIPTION
Description:

- JS and CSS files were using repository name `@ogcio/ogcio-ds` which was creating an additional folder, I have hardcoded it to `ogcio-ds` which then will just rename the `all.js` to a proper file name.

- Testing required if `dist` folder still exists in zip.

- TODO: remove `VERSION.txt`