### PR TITLE
fix: update environment variable usage for Storybook AWS deployment

### DIFF
--- a/.github/workflows/deploy-storybook-aws.yml
+++ b/.github/workflows/deploy-storybook-aws.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: '20.x'
 
       - run: npm i
+      - run: |
+          echo "DS_ENV=aws" >> .env
       - run: npm run build:storybook:dist
       - run: npm run storybook:build
 

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: '20.x'
 
       - run: npm i
+      - run: |
+          echo "DS_ENV=github-pages" >> .env
       - run: npm run build:storybook:dist
       - run: npm run storybook:build
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,7 @@ export default {
     '@storybook/addon-links',
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
-    "@storybook/addon-essentials",
+    '@storybook/addon-essentials',
     // reference: <https://storybook.js.org/docs/writing-docs/mdx#markdown-tables-arent-rendering-correctly>
     {
       name: '@storybook/addon-docs',
@@ -24,7 +24,7 @@ export default {
           },
         },
       },
-    }
+    },
   ],
   framework: {
     name: '@storybook/react-vite',
@@ -44,9 +44,9 @@ export default {
     autodocs: true,
   },
   viteFinal: async (config, { configType }) => {
-    if (configType === 'PRODUCTION') {
-      config.base = "/ogcio-ds/";
+    if (configType === 'PRODUCTION' && process.env.DS_ENV === 'github-pages') {
+      config.base = '/ogcio-ds/';
     }
     return config;
-  }
+  },
 };


### PR DESCRIPTION
- Check `process.env.DS_ENV` on `viteFinal`.
- Use `/ogcio-ds/` for Github pages else, default path `/`.

TODO: testing required. 