### PR TITLE
fix: add radio and text input accessibility

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,6 +14,7 @@ export default {
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
     '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
     // reference: <https://storybook.js.org/docs/writing-docs/mdx#markdown-tables-arent-rendering-correctly>
     {
       name: '@storybook/addon-docs',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@chromatic-com/storybook": "^1.3.3",
         "@etchteam/storybook-addon-css-variables-theme": "^3.0.0",
         "@percy/cli": "^1.12.0",
+        "@storybook/addon-a11y": "^8.1.11",
         "@storybook/addon-essentials": "^8.0.9",
         "@storybook/addon-interactions": "^8.0.9",
         "@storybook/addon-links": "^8.0.9",
@@ -3991,6 +3992,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "8.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.1.11.tgz",
+      "integrity": "sha512-JFiY/ASwMOCf3MOi7GtKOvLn62jhcIYV2he90l1SSnXxsDmurETVumyAdTQtQtUQpAJI+l0Ed4uLVjzAxkGreg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addon-highlight": "8.1.11",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/addon-highlight": {
+      "version": "8.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.1.11.tgz",
+      "integrity": "sha512-Iu8FCAd4ETsB6QF4xDE/OLLZY3HOFopuLM5KE0f58jnccF5zAVGr1Rj/54p6TeK0PEou0tLRPFuZs+LPlEzrSw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "8.1.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.1.6.tgz",
@@ -7431,6 +7459,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@chromatic-com/storybook": "^1.3.3",
     "@etchteam/storybook-addon-css-variables-theme": "^3.0.0",
     "@percy/cli": "^1.12.0",
+    "@storybook/addon-a11y": "^8.1.11",
     "@storybook/addon-essentials": "^8.0.9",
     "@storybook/addon-interactions": "^8.0.9",
     "@storybook/addon-links": "^8.0.9",

--- a/src/govie/components/input/TextInput.stories.js
+++ b/src/govie/components/input/TextInput.stories.js
@@ -193,6 +193,11 @@ const createTextInputElement = (args) => {
     textInput.setAttribute('autocomplete', args.autocomplete);
   }
 
+  // Use the hint value when only a hint is available.
+  if (args.hint && !args.label) {
+    textInput.setAttribute('aria-label', args.hint);
+  }
+
   if (textInputDescribedBy.length > 0) {
     textInput.setAttribute('aria-describedby', textInputDescribedBy.join(' '));
   }

--- a/src/govie/components/radios/radios.mjs
+++ b/src/govie/components/radios/radios.mjs
@@ -1,8 +1,8 @@
-import '../../vendor/polyfills/Function/prototype/bind.mjs'
+import '../../vendor/polyfills/Function/prototype/bind.mjs';
 // addEventListener, event.target normalization and DOMContentLoaded
-import '../../vendor/polyfills/Event.mjs'
-import '../../vendor/polyfills/Element/prototype/classList.mjs'
-import { nodeListForEach } from '../../common.mjs'
+import '../../vendor/polyfills/Event.mjs';
+import '../../vendor/polyfills/Element/prototype/classList.mjs';
+import { nodeListForEach } from '../../common.mjs';
 
 /**
  * Radios component
@@ -10,9 +10,9 @@ import { nodeListForEach } from '../../common.mjs'
  * @class
  * @param {HTMLElement} $module - HTML element to use for radios
  */
-function Radios ($module) {
-  this.$module = $module
-  this.$inputs = $module.querySelectorAll('input[type="radio"]')
+function Radios($module) {
+  this.$module = $module;
+  this.$inputs = $module.querySelectorAll('input[type="radio"]');
 }
 
 /**
@@ -30,49 +30,58 @@ function Radios ($module) {
  * the reveal in sync with the radio state.
  */
 Radios.prototype.init = function () {
-  var $module = this.$module
-  var $inputs = this.$inputs
+  var $module = this.$module;
+  var $inputs = this.$inputs;
 
   nodeListForEach($inputs, function ($input) {
-    var target = $input.getAttribute('data-aria-controls')
+    var target = $input.getAttribute('data-aria-controls');
 
     // Skip radios without data-aria-controls attributes, or where the
     // target element does not exist.
     if (!target || !document.getElementById(target)) {
-      return
+      return;
     }
 
     // Promote the data-aria-controls attribute to a aria-controls attribute
     // so that the relationship is exposed in the AOM
-    $input.setAttribute('aria-controls', target)
-    $input.removeAttribute('data-aria-controls')
-  })
+    $input.setAttribute('aria-controls', target);
+    $input.removeAttribute('data-aria-controls');
+  });
 
   // When the page is restored after navigating 'back' in some browsers the
   // state of form controls is not restored until *after* the DOMContentLoaded
   // event is fired, so we need to sync after the pageshow event in browsers
   // that support it.
   if ('onpageshow' in window) {
-    window.addEventListener('pageshow', this.syncAllConditionalReveals.bind(this))
+    window.addEventListener(
+      'pageshow',
+      this.syncAllConditionalReveals.bind(this),
+    );
   } else {
-    window.addEventListener('DOMContentLoaded', this.syncAllConditionalReveals.bind(this))
+    window.addEventListener(
+      'DOMContentLoaded',
+      this.syncAllConditionalReveals.bind(this),
+    );
   }
 
   // Although we've set up handlers to sync state on the pageshow or
   // DOMContentLoaded event, init could be called after those events have fired,
   // for example if they are added to the page dynamically, so sync now too.
-  this.syncAllConditionalReveals()
+  this.syncAllConditionalReveals();
 
   // Handle events
-  $module.addEventListener('click', this.handleClick.bind(this))
-}
+  $module.addEventListener('click', this.handleClick.bind(this));
+};
 
 /**
  * Sync the conditional reveal states for all inputs in this $module.
  */
 Radios.prototype.syncAllConditionalReveals = function () {
-  nodeListForEach(this.$inputs, this.syncConditionalRevealWithInputState.bind(this))
-}
+  nodeListForEach(
+    this.$inputs,
+    this.syncConditionalRevealWithInputState.bind(this),
+  );
+};
 
 /**
  * Sync conditional reveal with the input state
@@ -83,15 +92,17 @@ Radios.prototype.syncAllConditionalReveals = function () {
  * @param {HTMLInputElement} $input - Radio input
  */
 Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
-  var $target = document.getElementById($input.getAttribute('aria-controls'))
+  var $target = document.getElementById($input.getAttribute('aria-controls'));
 
   if ($target && $target.classList.contains('govie-radios__conditional')) {
-    var inputIsChecked = $input.checked
+    var inputIsChecked = $input.checked;
 
-    $input.setAttribute('aria-expanded', inputIsChecked)
-    $target.classList.toggle('govie-radios__conditional--hidden', !inputIsChecked)
+    $target.classList.toggle(
+      'govie-radios__conditional--hidden',
+      !inputIsChecked,
+    );
   }
-}
+};
 
 /**
  * Click event handler
@@ -104,25 +115,30 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
  * @param {MouseEvent} event - Click event
  */
 Radios.prototype.handleClick = function (event) {
-  var $clickedInput = event.target
+  var $clickedInput = event.target;
 
   // Ignore clicks on things that aren't radio buttons
   if ($clickedInput.type !== 'radio') {
-    return
+    return;
   }
 
   // We only need to consider radios with conditional reveals, which will have
   // aria-controls attributes.
-  var $allInputs = document.querySelectorAll('input[type="radio"][aria-controls]')
+  var $allInputs = document.querySelectorAll(
+    'input[type="radio"][aria-controls]',
+  );
 
-  nodeListForEach($allInputs, function ($input) {
-    var hasSameFormOwner = ($input.form === $clickedInput.form)
-    var hasSameName = ($input.name === $clickedInput.name)
+  nodeListForEach(
+    $allInputs,
+    function ($input) {
+      var hasSameFormOwner = $input.form === $clickedInput.form;
+      var hasSameName = $input.name === $clickedInput.name;
 
-    if (hasSameName && hasSameFormOwner) {
-      this.syncConditionalRevealWithInputState($input)
-    }
-  }.bind(this))
-}
+      if (hasSameName && hasSameFormOwner) {
+        this.syncConditionalRevealWithInputState($input);
+      }
+    }.bind(this),
+  );
+};
 
-export default Radios
+export default Radios;


### PR DESCRIPTION
Used axe devtools and `@storybook/addon-a11y` to identify accessibility issues with the components. 

- Radio button `aria-expanded` attribute removed.
- `aria-label` added for input hints without label.
- Auto formatting on `radios.mjs`.
- Add `@storybook/addon-a11y` plugin.

Testing on Storybook using `@storybook/addon-a11y`:
![Screenshot 2024-06-26 at 17 46 34](https://github.com/ogcio/ogcio-ds/assets/164040832/e2b51b80-b371-4e8f-85b9-d8b834928870)
![Screenshot 2024-06-26 at 17 55 59](https://github.com/ogcio/ogcio-ds/assets/164040832/b83cffb8-7027-424f-a324-24ee59fd8e9b)