### PR TITLE
docs: rename ogcio with gov-ie naming conventions

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -139,7 +139,7 @@ export const parameters = {
           'Install using precompiled files',
           'Import CSS, assets and JavaScript',
           'Configure components with JavaScript',
-          'Localise OGCIO-DS',
+          'Localise Gov IE DS',
           'Support Internet Explorer 8',
           'JavaScript API Reference',
           'Sass API Reference',

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
-# OGCIO Design System
+# Gov IE Design System
 
-OGCIO-DS contains the code you need to start building a user interface for government platforms and services.
+Gov IE DS contains the code you need to start building a user interface for government platforms and services.
 
-See live examples of OGCIO components, and guidance on when to use them in your service, in the [OGCIO Design System](https://ogcio.github.io/ogcio-ds/).
+See live examples of Gov IE components, and guidance on when to use them in your service, in the [Gov IE Design System](https://ogcio.github.io/ogcio-ds/).
 
 ## Contact the team
 
-If you want to know more about OGCIO-DS, you can go to the [Contact us](https://www.design-system.ogcio.gov.ie/contact/) page.
+If you want to know more about Gov IE Design System, you can go to the [Contact us](https://www.design-system.ogcio.gov.ie/contact/) page.
 
 ## Quick start
 
-There are 2 ways to start using OGCIO-DS components in your app.
+There are 2 ways to start using Gov IE Design System components in your app.
 
-Once installed, you will be able to use the code from the examples in the OGCIO-DS in your service.
+Once installed, you will be able to use the code from the examples in the Gov IE Design System in your service.
 
 ### 1. Install with npm (recommended)
 
-We recommend [installing OGCIO-DS using node package manager
+We recommend [installing Gov IE Design System using node package manager
 (npm)](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-install-with-npm--docs).
 
 ### 2. Install using compiled files
 
-You can also install OGCIO-DS by [copying our CSS, JavaScript and asset files into your project](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-install-using-precompiled-files--docs).
+You can also install Gov IE Design System by [copying our CSS, JavaScript and asset files into your project](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-install-using-precompiled-files--docs).
 
 ## Accessibility
 
-The OGCIO-DS team works hard to ensure that OGCIO-DS is accessible.
+The Gov IE DS team works hard to ensure that Gov IE DS is accessible.
 
 Using Frontend will help your service meet [level AA of WCAG 2.1](https://www.w3.org/TR/WCAG21/). But you must still check that your service meets accessibility requirements, especially if you extend or modify components.
 
 You should also use:
 
-- [the JavaScript from OGCIO-DS](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-import-css-assets-and-javascript--docs)
+- [the JavaScript from Gov IE DS](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-import-css-assets-and-javascript--docs)
 - [a separate stylesheet](https://ogcio.github.io/ogcio-ds/?path=/docs/docs-support-internet-explorer-8--docs) if you support Internet Explorer 8
 
-You can also read the [accessibility statement for OGCIO-DS](https://www.design-system.ogcio.gov.ie/accessibility/)
+You can also read the [accessibility statement for Gov IE DS](https://www.design-system.ogcio.gov.ie/accessibility/)
 
 ## Getting updates
 
-To be notified when there’s a new release, you can [watch the ogcio-ds Github repository](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository)
+To be notified when there’s a new release, you can [watch the Gov IE DS Github repository](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository)
 
 Find out how to [update with npm](https://ogcio.github.io/ogcio-ds/?path=/story/docs-update-with-npm--docs/).
 
@@ -128,7 +128,7 @@ To uninstall Husky hooks, run the following command:
 npm run husky:uninstall
 ```
 
-## OGCIO-DS package publishing
+## Gov IE DS package publishing
 
 - Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) and [squash commits](https://github.com/googleapis/release-please?tab=readme-ov-file#linear-git-commit-history-use-squash-merge) to `main`
 - Versioning and npm package publishing is handled by the [Release Please GitHub action](https://github.com/google-github-actions/release-please-action)
@@ -147,4 +147,4 @@ When changes are pushed to `main` branch on GitHub, [Github Actions][github-acti
 
 ## Contributing
 
-Contributors to OGCIO repositories are expected to follow the [Contributor Guide](https://ogcio.github.io/ogcio-ds-website/help/how-to-contribute/).
+Contributors to Gov IE repositories are expected to follow the [Contributor Guide](https://ogcio.github.io/ogcio-ds-website/help/how-to-contribute/).

--- a/src/govie/README.md
+++ b/src/govie/README.md
@@ -2,7 +2,7 @@
 
 ## Structure
 
-OGCIO-DS is broken into a number of layers in order to help provide a
+Gov IE DS is broken into a number of layers in order to help provide a
 logical structure, loosely following the conventions of [ITCSS].
 
 1. [Settings](#settings)

--- a/src/govie/all.mjs
+++ b/src/govie/all.mjs
@@ -1,27 +1,27 @@
-import { nodeListForEach } from './common.mjs'
-import Accordion from './components/accordion/accordion.mjs'
-import Button from './components/button/button.mjs'
-import CharacterCount from './components/character-count/character-count.mjs'
-import Checkboxes from './components/checkboxes/checkboxes.mjs'
-import Details from './components/details/details.mjs'
-import ErrorSummary from './components/error-summary/error-summary.mjs'
-import Header from './components/header/header.mjs'
-import Navigation from './components/navigation/navigation.mjs'
-import NotificationBanner from './components/notification-banner/notification-banner.mjs'
-import ProgressStepper from './components/progress-stepper/progress-stepper.mjs'
-import Radios from './components/radios/radios.mjs'
-import SkipLink from './components/skip-link/skip-link.mjs'
-import StepByStepNav from './components/step-by-step-navigation/step-by-step-navigation.mjs'
-import Superheader from './components/superheader/superheader.mjs'
-import Tabs from './components/tabs/tabs.mjs'
-import Tick from './components/tick/tick.mjs'
-import Tooltip from './components/tooltip/tooltip.mjs'
+import { nodeListForEach } from './common.mjs';
+import Accordion from './components/accordion/accordion.mjs';
+import Button from './components/button/button.mjs';
+import CharacterCount from './components/character-count/character-count.mjs';
+import Checkboxes from './components/checkboxes/checkboxes.mjs';
+import Details from './components/details/details.mjs';
+import ErrorSummary from './components/error-summary/error-summary.mjs';
+import Header from './components/header/header.mjs';
+import Navigation from './components/navigation/navigation.mjs';
+import NotificationBanner from './components/notification-banner/notification-banner.mjs';
+import ProgressStepper from './components/progress-stepper/progress-stepper.mjs';
+import Radios from './components/radios/radios.mjs';
+import SkipLink from './components/skip-link/skip-link.mjs';
+import StepByStepNav from './components/step-by-step-navigation/step-by-step-navigation.mjs';
+import Superheader from './components/superheader/superheader.mjs';
+import Tabs from './components/tabs/tabs.mjs';
+import Tick from './components/tick/tick.mjs';
+import Tooltip from './components/tooltip/tooltip.mjs';
 
 /**
  * Initialise all components
  *
  * Use the `data-module` attributes to find, instantiate and init all of the
- * components provided as part of OGCIO-DS.
+ * components provided as part of Gov IE DS.
  *
  * @param {object} [config] - Config
  * @param {HTMLElement} [config.scope=document] - Scope to query for components
@@ -32,111 +32,111 @@ import Tooltip from './components/tooltip/tooltip.mjs'
  * @param {object} [config.notificationBanner] - Notification Banner config
  */
 function initAll(config) {
-  config = typeof config !== 'undefined' ? config : {}
+  config = typeof config !== 'undefined' ? config : {};
 
-  // Allow the user to initialise OGCIO-DS in only certain sections of the page
+  // Allow the user to initialise Gov IE DS in only certain sections of the page
   // Defaults to the entire document if nothing is set.
-  var $scope = typeof config.scope !== 'undefined' ? config.scope : document
+  var $scope = typeof config.scope !== 'undefined' ? config.scope : document;
 
-  var $accordions = $scope.querySelectorAll('[data-module="govie-accordion"]')
+  var $accordions = $scope.querySelectorAll('[data-module="govie-accordion"]');
   nodeListForEach($accordions, function ($accordion) {
-    new Accordion($accordion, config.accordion).init()
-  })
+    new Accordion($accordion, config.accordion).init();
+  });
 
-  var $buttons = $scope.querySelectorAll('[data-module="govie-button"]')
+  var $buttons = $scope.querySelectorAll('[data-module="govie-button"]');
   nodeListForEach($buttons, function ($button) {
-    new Button($button, config.button).init()
-  })
+    new Button($button, config.button).init();
+  });
 
   var $iconButtons = $scope.querySelectorAll(
-    '[data-module="govie-icon-button"]'
-  )
+    '[data-module="govie-icon-button"]',
+  );
   nodeListForEach($iconButtons, function ($button) {
-    new Button($button, config.button).init()
-  })
+    new Button($button, config.button).init();
+  });
 
   var $characterCounts = $scope.querySelectorAll(
-    '[data-module="govie-character-count"]'
-  )
+    '[data-module="govie-character-count"]',
+  );
   nodeListForEach($characterCounts, function ($characterCount) {
-    new CharacterCount($characterCount, config.characterCount).init()
-  })
+    new CharacterCount($characterCount, config.characterCount).init();
+  });
 
-  var $checkboxes = $scope.querySelectorAll('[data-module="govie-checkboxes"]')
+  var $checkboxes = $scope.querySelectorAll('[data-module="govie-checkboxes"]');
   nodeListForEach($checkboxes, function ($checkbox) {
-    new Checkboxes($checkbox).init()
-  })
+    new Checkboxes($checkbox).init();
+  });
 
-  var $details = $scope.querySelectorAll('[data-module="govie-details"]')
+  var $details = $scope.querySelectorAll('[data-module="govie-details"]');
   nodeListForEach($details, function ($detail) {
-    new Details($detail).init()
-  })
+    new Details($detail).init();
+  });
 
   // Find first error summary module to enhance.
   var $errorSummary = $scope.querySelector(
-    '[data-module="govie-error-summary"]'
-  )
+    '[data-module="govie-error-summary"]',
+  );
   if ($errorSummary) {
-    new ErrorSummary($errorSummary, config.errorSummary).init()
+    new ErrorSummary($errorSummary, config.errorSummary).init();
   }
 
   // Find first header module to enhance.
-  var $header = $scope.querySelector('[data-module="govie-header"]')
+  var $header = $scope.querySelector('[data-module="govie-header"]');
   if ($header) {
-    new Header($header).init()
+    new Header($header).init();
   }
 
   // Find first header module to enhance.
-  var $superheader = $scope.querySelector('[data-module="govie-superheader"]')
+  var $superheader = $scope.querySelector('[data-module="govie-superheader"]');
   if ($superheader) {
-    new Superheader($superheader).init()
+    new Superheader($superheader).init();
   }
 
   var $notificationBanners = $scope.querySelectorAll(
-    '[data-module="govie-notification-banner"]'
-  )
+    '[data-module="govie-notification-banner"]',
+  );
   nodeListForEach($notificationBanners, function ($notificationBanner) {
     new NotificationBanner(
       $notificationBanner,
-      config.notificationBanner
-    ).init()
-  })
+      config.notificationBanner,
+    ).init();
+  });
 
-  var $radios = $scope.querySelectorAll('[data-module="govie-radios"]')
+  var $radios = $scope.querySelectorAll('[data-module="govie-radios"]');
   nodeListForEach($radios, function ($radio) {
-    new Radios($radio).init()
-  })
+    new Radios($radio).init();
+  });
 
   // Find first skip link module to enhance.
-  var $skipLink = $scope.querySelector('[data-module="govie-skip-link"]')
-  new SkipLink($skipLink).init()
+  var $skipLink = $scope.querySelector('[data-module="govie-skip-link"]');
+  new SkipLink($skipLink).init();
 
-  var $tabs = $scope.querySelectorAll('[data-module="govie-tabs"]')
+  var $tabs = $scope.querySelectorAll('[data-module="govie-tabs"]');
   nodeListForEach($tabs, function ($tabs) {
-    new Tabs($tabs).init()
-  })
+    new Tabs($tabs).init();
+  });
 
-  var $stepByStepNav = $scope.querySelector('#govie-step-by-step-navigation')
-  new StepByStepNav($stepByStepNav).init()
+  var $stepByStepNav = $scope.querySelector('#govie-step-by-step-navigation');
+  new StepByStepNav($stepByStepNav).init();
 
   var $progressSteppers = $scope.querySelectorAll(
-    '[data-module="govie-progress-stepper"]'
-  )
+    '[data-module="govie-progress-stepper"]',
+  );
   nodeListForEach($progressSteppers, function ($progressStepper) {
-    new ProgressStepper($progressStepper).init()
-  })
+    new ProgressStepper($progressStepper).init();
+  });
 
-  var $ticks = $scope.querySelectorAll('[data-module="govie-tick"]')
+  var $ticks = $scope.querySelectorAll('[data-module="govie-tick"]');
   nodeListForEach($ticks, function ($tick) {
-    new Tick($tick).init()
-  })
+    new Tick($tick).init();
+  });
 
-  var $tooltips = $scope.querySelectorAll('[data-module="govie-tooltip"]')
+  var $tooltips = $scope.querySelectorAll('[data-module="govie-tooltip"]');
   nodeListForEach($tooltips, function ($tooltip) {
-    new Tooltip($tooltip).init()
-  })
+    new Tooltip($tooltip).init();
+  });
 
-  new Navigation().init()
+  new Navigation().init();
 }
 
 export {
@@ -158,7 +158,7 @@ export {
   Tabs,
   Tick,
   Tooltip,
-}
+};
 
 /**
  * Config for all components

--- a/src/govie/components/header/Header.stories.js
+++ b/src/govie/components/header/Header.stories.js
@@ -7,7 +7,7 @@ export default {
     docs: {
       description: {
         component:
-          'The OGCIO-DS header shows users that they are on gov.ie and which service they are using.',
+          'The Gov IE DS header shows users that they are on gov.ie and which service they are using.',
       },
     },
   },

--- a/src/govie/templates/basic-page/BasicPage.stories.js
+++ b/src/govie/templates/basic-page/BasicPage.stories.js
@@ -19,7 +19,7 @@ const Template = () => {
   
   <head>
     <meta charset="utf-8">
-    <title>OGCIO-DS</title>
+    <title>Gov IE DS</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/storybook/stories/api-reference/sass-api-reference.mdx
+++ b/storybook/stories/api-reference/sass-api-reference.mdx
@@ -431,7 +431,7 @@ $govie-show-breakpoints: false;
 #### $govie-font-family-lato
 
 List of font families to use if using Lato (the default font 'stack for
-OGCIO-DS)
+Gov IE DS)
 
 #### Default value
 

--- a/storybook/stories/get-started/configure-components-javascript.mdx
+++ b/storybook/stories/get-started/configure-components-javascript.mdx
@@ -5,7 +5,7 @@ import { Link } from '../components/Link.jsx';
 
 # Configure components with JavaScript
 
-You can configure some of the components in OGCIO-DS to customise their behaviour.
+You can configure some of the components in Gov IE DS to customise their behaviour.
 
 You can configure a component by:
 

--- a/storybook/stories/get-started/get-started.mdx
+++ b/storybook/stories/get-started/get-started.mdx
@@ -5,31 +5,31 @@ import { Link } from '../components/Link.jsx';
 
 # Get started
 
-Get one OGCIO-DS component working in your application, so you can test everything works before you add more components or styles.
+Get one Gov IE DS component working in your application, so you can test everything works before you add more components or styles.
 
 You will need to do all the following steps to get your component working.
 
-1. Install OGCIO-DS package.
+1. Install Gov IE DS package.
 2. Add the HTML for a component to your application.
 3. Get the CSS working.
 4. Get the font and images working.
 5. Get the JavaScript working.
 
-## 1. Install OGCIO-DS package
+## 1. Install Gov IE DS package
 
-- <Link href='?path=/docs/docs-install-with-npm--docs'>Install OGCIO-DS using npm</Link>
+- You can <Link href="?path=/docs/docs-install-with-npm--docs">install Gov IE DS using npm</Link>.
 
-- If you've <Link href='?path=/story/docs-install-using-precompiled-files--docs'>installed using precompiled files</Link>, get started with a <Link href='?path=/story/docs-install-using-precompiled-files--docs#basic-example-page'>a basic page instead</Link>
+- If you've <Link href='?path=/story/docs-install-using-precompiled-files--docs'>installed using precompiled files</Link>, get started with a <Link href='?path=/story/docs-install-using-precompiled-files--docs#basic-example-page'>a basic page instead</Link>.
 
 ## 2. Add the HTML for a component to your application
 
-Go to the <Link href='?path=/docs/typography-accordion--default'>example accordion component</Link>
+- Go to the <Link href='?path=/docs/typography-accordion--default'>example accordion component</Link>.
 
-Paste the HTML into a page or template in your application.
+- Paste the HTML into a page or template in your application.
 
 ## 3. Get the CSS working
 
-1. Add the following to the main Sass file in your project, so your Sass compiler adds all of OGCIO-DS styles to your CSS file.
+1. Add the following to the main Sass file in your project, so your Sass compiler adds all of Gov IE DS styles to your CSS file.
 
 ```sass
 @import '@ogcio/ogcio-ds/govie/all';
@@ -48,11 +48,11 @@ Run your application and check that the accordion displays correctly.
 
 The accordion will use a generic font until you get the font and images working, and will not be interactive until you get the JavaScript working.
 
-There are also different ways you can <Link href='?path=/docs/docs-import-css-assets-and-javascript--docs'>import OGCIO-DS CSS</Link>.
+There are also different ways you can <Link href='?path=/docs/docs-import-css-assets-and-javascript--docs'>import Gov IE DS CSS</Link>.
 
 ## 4. Get the font and images working
 
-Your component will not use the right font or images until you've added OGCIO-DS assets to your application.
+Your component will not use the right font or images until you've added Gov IE DS assets to your application.
 
 1. Copy the following 2 folders:
 
@@ -92,7 +92,7 @@ Run your application and check it works the same way as the Design System accord
 
 In your live application:
 
-- You must use `initAll` to initialise all components that use OGCIO-DS JavaScript, or some components will not work correctly for disabled users who use assistive technologies
+- You must use `initAll` to initialise all components that use Gov IE DS JavaScript, or some components will not work correctly for disabled users who use assistive technologies
 
 We recommend <Link href='?path=/docs/docs-import-css-assets-and-javascript--docs#import-javascript'>using an automated task or your build pipeline</Link> instead of copying the files manually
 

--- a/storybook/stories/get-started/import-assets.mdx
+++ b/storybook/stories/get-started/import-assets.mdx
@@ -8,7 +8,7 @@ import { Canvas, Meta } from '@storybook/blocks';
 
 ### Import all the CSS
 
-To import all the Sass rules from OGCIO-DS, add the following to your Sass file:
+To import all the Sass rules from Gov IE DS, add the following to your Sass file:
 
 ```sass
 @import "@ogcio/ogcio-ds/govie/all";
@@ -21,7 +21,7 @@ If you want to improve how quickly your service's pages load in browsers, you ca
 - Import `@ogcio/ogcio-ds/govie/base` in your Sass file.
 - Import the parts of the CSS you need.
 
-For example, add the following to your Sass file to import the CSS you need for a basic OGCIO-DS page.
+For example, add the following to your Sass file to import the CSS you need for a basic Gov IE DS page.
 
 ```sass
 @import "@ogcio/ogcio-ds/govie/base";\n
@@ -48,16 +48,16 @@ To import the button component for example, add the following to your Sass file:
 
 ### Override with your own CSS
 
-If you want to override OGCIO-DS styles with your own styles, `@import` OGCIO-DS styles before your own Sass rules.
+If you want to override Gov IE DS styles with your own styles, `@import` Gov IE DS styles before your own Sass rules.
 
 <h2 id="fonts-and-images-assets">Font and image assets</h2>
 
-To use the font and image assets from OGCIO-DS, you can either:
+To use the font and image assets from Gov IE DS, you can either:
 
-- serve the assets from the OGCIO-DS assets folder - recommended
+- serve the assets from the Gov IE DS assets folder - recommended
 - copy the font and image files into your application
 
-### Serve the assets from the OGCIO-DS assets folder - recommended
+### Serve the assets from the Gov IE DS assets folder - recommended
 
 Set up your routing so that requests for files in `<YOUR-SITE-URL>/assets` are served from `/node_modules/@ogcio/ogcio-ds/govie/assets`.
 
@@ -78,7 +78,7 @@ If you decide to copy the assets instead, copy the:
 - `/node_modules/@ogcio/ogcio-ds/govie/assets/images` folder to `<YOUR-APP>/assets/images`
 - `/node_modules/@ogcio/ogcio-ds/govie/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
 
-You should use an automated task or your build pipeline to copy the files, so your project folder stays up to date when we update OGCIO-DS.
+You should use an automated task or your build pipeline to copy the files, so your project folder stays up to date when we update Gov IE DS.
 
 #### If you have your own folder structure
 
@@ -106,10 +106,11 @@ You can also use your own function to generate paths, for example if you're usin
 
 <h2 id="import-javascript">JavaScript</h2>
 
-To import the JavaScript from OGCIO-DS, you can either:
+To import the JavaScript from Gov IE DS, you can either:
 
-- add OGCIO-DS's JavaScript file to your HTML
+- add Gov IE DS's JavaScript file to your HTML
 - import JavaScript using a bundle
+
   r
 
 ### Add the JavaScript file to your HTML
@@ -163,7 +164,7 @@ if ($radios) {
 }
 ```
 
-If you need to import all of OGCIO-DS components, then run the `initAll` function to initialise them:
+If you need to import all of Gov IE DS components, then run the `initAll` function to initialise them:
 
 ```javascript
 import { initAll } from '@ogcio/ogcio-ds';

--- a/storybook/stories/get-started/install-with-files.mdx
+++ b/storybook/stories/get-started/install-with-files.mdx
@@ -5,7 +5,7 @@ import { Link, ReleaseLink } from '../components/Link.jsx';
 
 # Install using precompiled files
 
-You can install OGCIO-DS by copying our CSS, JavaScript and asset files into your project. If you install this way, you can try OGCIO-DS in your application without having to make many changes.
+You can install Gov IE DS by copying our CSS, JavaScript and asset files into your project. If you install this way, you can try Gov IE DS in your application without having to make many changes.
 
 > ! In your live application, you should install with Node.js package manager (npm) instead.
 
@@ -15,7 +15,7 @@ You'll not be able to:
 
 - Change <Link href='?path=/story/docs-sass-api-reference--docs'>Sass settings</Link>, for example override colours or set your own font
 - Import an individual component's CSS or JavaScript
-- Use OGCIO-DS colours or mixins in your custom code
+- Use Gov IE DS colours or mixins in your custom code
 
 ## Copy the files
 
@@ -32,7 +32,7 @@ You'll not be able to:
 <!doctype html>
 <html lang="en" className="govie-template ">
   <head>
-    <title>Example - OGCIO Design System</title>
+    <title>Example - Gov IE Design System</title>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
@@ -57,7 +57,7 @@ You'll not be able to:
 </html>
 ```
 
-2. Replace `<VERSION-NUMBER>` so the 3 filenames match the files you copied from OGCIO-DS GitHub repo.
+2. Replace `<VERSION-NUMBER>` so the 3 filenames match the files you copied from Gov IE DS GitHub repo.
 3. Go to the <Link href='?path=/docs/typography-accordion--default'>example accordion component</Link> on the Design System website and copy the HTML from the first example.
 4. Replace `<!-- component HTML -->` with the accordion HTML you copied.
 5. Run your application - you can check it works the same way as the <Link href="iframe.html?id=typography-accordion--default&viewMode=story">Design System accordion example</Link> by selecting the buttons and checking the accordion 'shows' and 'hides' sections.

--- a/storybook/stories/get-started/install-with-npm.mdx
+++ b/storybook/stories/get-started/install-with-npm.mdx
@@ -13,7 +13,7 @@ import { Link } from '../components/Link.jsx';
 npm init
 ```
 
-3. Install the OGCIO-DS package
+3. Install the Gov IE DS package
 
 ```
 npm install @ogcio/ogcio-ds --save

--- a/storybook/stories/get-started/localisation.mdx
+++ b/storybook/stories/get-started/localisation.mdx
@@ -1,11 +1,11 @@
 import { Canvas, Meta } from '@storybook/blocks';
 import { Link } from '../components/Link.jsx';
 
-<Meta title="Docs/Localise OGCIO-DS" />
+<Meta title="Docs/Localise Gov IE DS" />
 
-# Localise OGCIO-DS
+# Localise Gov IE DS
 
-OGCIO-DS uses English by default. You're responsible for providing any translations for any other language you need for your service.
+Gov IE DS uses English by default. You're responsible for providing any translations for any other language you need for your service.
 
 There are three types of text you might want to translate into another language.
 

--- a/storybook/stories/get-started/support-ie-8.mdx
+++ b/storybook/stories/get-started/support-ie-8.mdx
@@ -40,7 +40,7 @@ Setting the `$govie-is-ie8` variable to `true` when generating the stylesheet wi
 - include any conditional styles that target IE8
 - exclude any conditional styles that target browsers other than IE8
 
-You must set the variable before importing OGCIO-DS.
+You must set the variable before importing Gov IE DS.
 
 In most scenarios you should be able to create a separate stylesheet for IE8, set the `$govie-is-ie8` variable to true and then import your main application stylesheet without having to redefine anything else.
 
@@ -66,7 +66,7 @@ You should use the [oldie plugin](https://github.com/jonathantneal/oldie) for [p
 
 The oldie plugin is also able to flatten media queries, but this will already have been done as part of the stylesheet compilation in step 1.
 
-Doing this as a separate step allows us to keep the source of OGCIO-DS simple, without having to wrap syntax that would need to be transformed in mixins or functions.
+Doing this as a separate step allows us to keep the source of Gov IE DS simple, without having to wrap syntax that would need to be transformed in mixins or functions.
 
 ## 4. Include the IE8 stylesheet in your project
 

--- a/storybook/stories/get-started/update-with-npm.mdx
+++ b/storybook/stories/get-started/update-with-npm.mdx
@@ -5,11 +5,11 @@ import { Link } from '../components/Link.jsx';
 
 # Update using Node.js package manager (npm)
 
-You can update with Node.js package manager (npm) if you <Link href='?path=/docs/docs-install-with-npm--docs'>originally installed OGCIO-DS with npm</Link>.
+You can update with Node.js package manager (npm) if you <Link href='?path=/docs/docs-install-with-npm--docs'>originally installed Gov IE DS with npm</Link>.
 
 ## Find out which version you're using
 
-To find out which version of OGCIO-DS your project is using, you can run:
+To find out which version of Gov IE DS your project is using, you can run:
 
 ```
 npm list @ogcio/ogcio-ds
@@ -21,11 +21,11 @@ If you do not have command line access, you can see the version number in the `p
 "@ogcio/ogcio-ds": "0.0.8"
 ```
 
-## Update OGCIO-DS using npm
+## Update Gov IE DS using npm
 
-To find out the latest version of OGCIO-DS, check the [release notes](https://github.com/ogcio/ogcio-ds/releases) in the OGCIO-DS GitHub repository.
+To find out the latest version of Gov IE DS, check the [release notes](https://github.com/ogcio/ogcio-ds/releases) in the Gov IE DS GitHub repository.
 
-You may need to make code changes to keep OGCIO-DS working in your project, if the major version number changes when you update. The major version number is the first digit in the version number.
+You may need to make code changes to keep Gov IE DS working in your project, if the major version number changes when you update. The major version number is the first digit in the version number.
 
 To update to the most recent version, run:
 


### PR DESCRIPTION
- Replaced "OGCIO" with "Gov IE" texts.

TODOs:
- Replace repository and associated links as well.