### PR TITLE
docs: clean html string with redundant parenthesis

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -11,6 +11,14 @@ import { DocsContainer } from '@storybook/addon-docs';
 
 // export const decorators = [cssVariablesTheme]
 
+function cleanHtmlString(htmlString) {
+  // Remove the leading and trailing backticks and braces
+  if (htmlString.startsWith('{`') && htmlString.endsWith('`}')) {
+    htmlString = htmlString.slice(2, -2);
+  }
+  return htmlString;
+}
+
 export const decorators = [
   (Story, context) => {
     useEffect(() => {
@@ -28,15 +36,6 @@ export const decorators = [
 ];
 
 export const parameters = {
-  // actions: { argTypesRegex: '^on[A-Z].*' },
-  // cssVariables: {
-  //   files: {
-  //     'HSE theme': hseTheme,
-  //     'AGS theme': agsTheme,
-  //     'OGCIO theme': defaultTheme,
-  //   },
-  //   defaultTheme: 'OGCIO theme',
-  // },
   controls: {
     matchers: {
       color: /(background|color)$/i,
@@ -45,12 +44,13 @@ export const parameters = {
     sort: 'requiredFirst',
   },
   docs: {
-    source: { format: false },
+    source: {
+      transform: (code) => {
+        // Work around solution to remove extra parenthesis like ` and {}
+        return cleanHtmlString(code);
+      },
+    },
     container: ({ children, context }) => {
-      // let newContext;
-      // cssVariablesTheme((c) => (newContext = c), context);
-      //    <DocsContainer context={newContext}>
-
       return (
         <DocsContainer context={context}>
           <div className="sb-unstyled">{children}</div>


### PR DESCRIPTION
- Use the `transform` function from the storybook [API](https://storybook.js.org/docs/api/doc-blocks/doc-block-source) to fix the redundant parenthesis like ` and {}.
- Removed comments.

Before:
<img width="1415" alt="Screenshot 2024-07-10 at 13 55 03" src="https://github.com/ogcio/ogcio-ds/assets/164040832/3470d3c1-45f6-4770-ace6-c75b1b7aacd4">

After:
<img width="1043" alt="Screenshot 2024-07-10 at 13 54 34" src="https://github.com/ogcio/ogcio-ds/assets/164040832/ea6e4dbc-bd46-4423-9e16-aa931538c33c">

