### PR TITLE
docs: usage of `govie-label` in combination with `govie-label--s`

### DIFF
--- a/src/govie/components/date-input/DateInput.stories.js
+++ b/src/govie/components/date-input/DateInput.stories.js
@@ -89,7 +89,7 @@ const createErrorMessage = (args) => {
 
 const createInputItemLabel = (fieldId, itemType) => {
   const label = document.createElement('label');
-  label.className = 'govie-label--s govie-date-input__label';
+  label.className = 'govie-label govie-label--s govie-date-input__label';
   label.setAttribute('for', `${fieldId}-${itemType.toLowerCase()}`);
   label.innerText = itemType;
 

--- a/src/govie/components/file-upload/FileUpload.stories.js
+++ b/src/govie/components/file-upload/FileUpload.stories.js
@@ -57,7 +57,7 @@ const createErrorMessage = (args) => {
 
 const createLabel = (args) => {
   const label = document.createElement('label');
-  label.className = 'govie-label--s';
+  label.className = 'govie-label govie-label--s';
   label.setAttribute('for', `${args.fieldId}`);
   label.innerText = args.label;
 

--- a/src/govie/components/input/TextInput.stories.js
+++ b/src/govie/components/input/TextInput.stories.js
@@ -132,7 +132,7 @@ const createHintElement = (args) => {
 };
 
 const createLabelElement = (args) => {
-  const labelClassNames = ['govie-label--s'];
+  const labelClassNames = ['govie-label govie-label--s'];
 
   if (args.labelAsHeading) {
     labelClassNames.push('govie-label--l');

--- a/src/govie/components/label/Label.stories.js
+++ b/src/govie/components/label/Label.stories.js
@@ -23,7 +23,7 @@ export default {
 
 const Template = (args) => {
   const label = document.createElement('label');
-  label.className = 'govie-label--s';
+  label.className = 'govie-label govie-label--s';
   label.innerHTML = args.text;
 
   return beautifyHtmlNode(label);

--- a/src/govie/components/select/Select.stories.js
+++ b/src/govie/components/select/Select.stories.js
@@ -45,7 +45,7 @@ const Template = (args) => {
   const classnames = ['govie-form-group'];
 
   const label = document.createElement('label');
-  label.className = 'govie-label--s';
+  label.className = 'govie-label govie-label--s';
   label.setAttribute('for', args.id);
   label.innerText = args.label;
 


### PR DESCRIPTION
Usage of `govie-label` in combination with `govie-label--s` to fix display.

Testing with few components on Storybook:

![Screenshot 2024-07-15 at 13 49 43](https://github.com/user-attachments/assets/5cdeb0b0-d028-4ed3-b9c7-b1e2478c1faa)
![Screenshot 2024-07-15 at 13 49 50](https://github.com/user-attachments/assets/b6ae7f92-60a2-48ea-a6a0-b1a9ce587fd6)
![Screenshot 2024-07-15 at 13 50 13](https://github.com/user-attachments/assets/eef4046d-09b0-4fbb-bf51-ebe5422a1d27)
