### PR TITLE
fix: inline radio item style specification

### DIFF
--- a/src/govie/components/radios/_index.scss
+++ b/src/govie/components/radios/_index.scss
@@ -164,7 +164,7 @@
       .govie-radios__item {
         margin-right: govie-spacing(4);
         float: left;
-        clear: none !important;
+        clear: none;
       }
     }
   }
@@ -374,7 +374,7 @@
     // Inline radios
     // =========================================================
 
-    .govie-radios--inline {
+    &.govie-radios--inline {
       @include govie-media-query($from: tablet) {
         @include govie-clearfix;
 
@@ -451,6 +451,18 @@
       padding-left: $label-offset;
       float: left;
       clear: left;
+    }
+
+    &.govie-radios--inline {
+      @include govie-media-query($from: tablet) {
+        @include govie-clearfix;
+
+        .govie-radios__item {
+          margin-right: govie-spacing(4);
+          float: left;
+          clear: none;
+        }
+      }
     }
 
     // Shift the touch target into the left margin so that the visible edge of

--- a/src/govie/components/radios/_index.scss
+++ b/src/govie/components/radios/_index.scss
@@ -164,7 +164,7 @@
       .govie-radios__item {
         margin-right: govie-spacing(4);
         float: left;
-        clear: none;
+        clear: none !important;
       }
     }
   }
@@ -450,6 +450,7 @@
       margin-bottom: 0;
       padding-left: $label-offset;
       float: left;
+      clear: left;
     }
 
     // Shift the touch target into the left margin so that the visible edge of


### PR DESCRIPTION
- Updated styles for `govie-radios--inline` to `--medium` radios. 
- Addition of `govie-radios--inline` to `--small` radios.

[Issue: 223](https://github.com/ogcio/ogcio-ds/issues/223)

Tested it locally.

Before:
![Screenshot 2024-08-08 at 13 33 56](https://github.com/user-attachments/assets/2731cd5f-7f1a-44c5-b109-b93026fe5e9a)

After:
![Screenshot 2024-08-08 at 13 32 29](https://github.com/user-attachments/assets/f1f097e3-d45d-4a1a-83c7-c87c356f87e6)
